### PR TITLE
V1.0

### DIFF
--- a/asset/style.css
+++ b/asset/style.css
@@ -163,6 +163,16 @@ a:hover.item{
   font-size: 23px;
   line-height: 40px;
 }
+.article.huge .post h2{
+  margin-top: 45px;
+  margin-bottom: 20px;
+  font-weight: 500;
+}
+.article.huge .post .body pre{
+  background-color: #042f39;
+  color: white;
+  border-radius: 4px;
+}
 
 .pagenavi {
   display: flex;

--- a/asset/style.css
+++ b/asset/style.css
@@ -169,9 +169,12 @@ a:hover.item{
   font-weight: 500;
 }
 .article.huge .post .body pre{
-  background-color: #042f39;
+  background-color: #242424;
   color: white;
   border-radius: 4px;
+  padding: 8px;
+  border: #042f39 1px solid;
+  box-shadow: inset 0px 1px 5px #000;
 }
 
 .pagenavi {
@@ -365,6 +368,11 @@ span.smallcaps {
   .article.huge .post blockquote p {
     font-size: 20px;
     line-height: 30px;
+  }
+  .article.huge .post h2{
+    margin-top: 25px;
+    margin-bottom: 10px;
+    font-weight: 500;
   }
 
   .article.normal {


### PR DESCRIPTION
- 优化小标题样式
- 优化 `<pre>` 和 `<code>` 元素样式，现在在文章中插入代码样式更漂亮了——只是没有高亮。